### PR TITLE
Add support for pulling the full available history of a coin

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,16 @@ coincap = CoinCap()
 
 ### - Get coin history
 
-History can be 1, 7, 30, 90, 180, or 365 days
+History can be 1, 7, 30, 90, 180, 365 days or all available.  To pull history for one of the allowed time periods include the time period (in days) as the 2nd argument.  
+
+##### Examples:
  ```
  coincap.get_coin_history('ETH', 1)
+ ```
+
+ To pull all available history, omit the 2nd argument:
+ ```
+ coincap.get_coin_history('ETH')
  ```
  
 ##### Response

--- a/coincap/coincap.py
+++ b/coincap/coincap.py
@@ -71,3 +71,13 @@ class CoinCap(object):
         if days not in supported_days:
             raise Exception('{} days not supported, please pick from {}'.format(days, supported_days))
         return self._query_coincap('history/{}day/{}'.format(str(days), coin_ticker))
+
+    def get_coin_history(self, coin_ticker):
+        """
+        Returns the full history of a coin
+
+        :param coin_ticker: ticker for coin to get detail from
+        :return: JSON object with coin's full available history
+        """
+
+        return self._query_coincap('history/{}'.format(coin_ticker))

--- a/coincap/tests/coincap_tests.py
+++ b/coincap/tests/coincap_tests.py
@@ -18,6 +18,10 @@ class TestCoinCap(unittest.TestCase):
         response = self.coin_cap.get_coin_history('ETH', 7)
         assert isinstance(response, dict)
 
+    def test_full_history_success(self):
+        response = self.coin_cap.get_coin_history('ETH')
+        assert isinstance(response, dict)
+
     def test_coin_detail(self):
         response = self.coin_cap.get_coin_detail('BTC')
         assert isinstance(response, dict)


### PR DESCRIPTION
Add suport for the `/history/:coin` endpoint including a new test and updated `README.md`